### PR TITLE
fixed use after free issue in wav gzip

### DIFF
--- a/startool.cpp
+++ b/startool.cpp
@@ -3921,9 +3921,9 @@ int ConvertWav(const char *listfile, const char *file, int wave __attribute__((u
 		printf("Can't write %d bytes\n", EntrySize);
 	}
 
-	free(wavp);
-
 	gzclose(gf);
+
+	free(wavp);
 
 	return 0;
 }


### PR DESCRIPTION
gzclose(fp) will finish any pending writes, so freeing the write buffer
before closing the file is essentially referencing free'ed memory while the
close calls flushes the write buffer.