### PR TITLE
truncating any reads greater than 4k

### DIFF
--- a/mpq.cpp
+++ b/mpq.cpp
@@ -549,9 +549,10 @@ int CMpq::ExtractTo(unsigned char *mpqbuf, UInt32 entry, FILE *fpMpq)
 					length_write = 0;
 					explode(&param);
 					length_read = length_write;
-                                        if (length_read > 0x1000)
-					    printf("WARNING metod 0x08 explode calculated larger than 4k read, truncating\n");
-                                            length_read = 0x1000;
+                                        if (length_read > 0x1000) {
+						printf("WARNING metod 0x08 explode calculated larger than 4k read, truncating\n");
+						length_read = 0x1000;
+					}
 					iteration--;
 					if (iteration) {
 						read_buffer = write_buffer;

--- a/mpq.cpp
+++ b/mpq.cpp
@@ -522,7 +522,9 @@ int CMpq::ExtractTo(unsigned char *mpqbuf, UInt32 entry, FILE *fpMpq)
 			if (flag & 0x30000) {
 				Decode((UInt32 *) read_buffer, massive_base, crc_file, length_read / 4);		// . decode block (if file is coded)
 			}
-			if (length_read == 0x1000 || (j == num_block - 2 && length_read == (size_unpack & 0xFFF))) {		// . if block is unpacked (its length=0x1000 or its last block and length=remainder)
+			if (length_read >= 0x1000 || (j == num_block - 2 && length_read == (size_unpack & 0xFFF))) {		// . if block is unpacked (its length=0x1000 or its last block and length=remainder)
+                                if (length_read > 0x1000)
+                                    length_read = 0x1000;
 				memcpy(mpqptr, read_buffer, length_read);
 				mpqptr += length_read;
 //				fwrite(read_buffer, sizeof(char), length_read, fp_new);		// . write block "as is"
@@ -554,6 +556,8 @@ int CMpq::ExtractTo(unsigned char *mpqbuf, UInt32 entry, FILE *fpMpq)
 						read_buffer = write_buffer;
 						write_buffer = read_buffer_start;
 					}
+                                        if (length_read > 0x1000)
+                                            length_read = 0x1000;
 				}
 				if (metod & 0x01) { // Huffman
 					length_read =

--- a/mpq.cpp
+++ b/mpq.cpp
@@ -522,9 +522,7 @@ int CMpq::ExtractTo(unsigned char *mpqbuf, UInt32 entry, FILE *fpMpq)
 			if (flag & 0x30000) {
 				Decode((UInt32 *) read_buffer, massive_base, crc_file, length_read / 4);		// . decode block (if file is coded)
 			}
-			if (length_read >= 0x1000 || (j == num_block - 2 && length_read == (size_unpack & 0xFFF))) {		// . if block is unpacked (its length=0x1000 or its last block and length=remainder)
-                                if (length_read > 0x1000)
-                                    length_read = 0x1000;
+			if (length_read == 0x1000 || (j == num_block - 2 && length_read == (size_unpack & 0xFFF))) {		// . if block is unpacked (its length=0x1000 or its last block and length=remainder)
 				memcpy(mpqptr, read_buffer, length_read);
 				mpqptr += length_read;
 //				fwrite(read_buffer, sizeof(char), length_read, fp_new);		// . write block "as is"
@@ -551,13 +549,14 @@ int CMpq::ExtractTo(unsigned char *mpqbuf, UInt32 entry, FILE *fpMpq)
 					length_write = 0;
 					explode(&param);
 					length_read = length_write;
+                                        if (length_read > 0x1000)
+					    printf("WARNING metod 0x08 explode calculated larger than 4k read, truncating\n");
+                                            length_read = 0x1000;
 					iteration--;
 					if (iteration) {
 						read_buffer = write_buffer;
 						write_buffer = read_buffer_start;
 					}
-                                        if (length_read > 0x1000)
-                                            length_read = 0x1000;
 				}
 				if (metod & 0x01) { // Huffman
 					length_read =


### PR DESCRIPTION
the read_buffer and write_buffer are only designed to be 4k big
reading more than 4k to them messes with byte ordering in the MPQ
file, tileset\Jungle.vr4 (entry 1809) block header has entries at 5006bytes
(the 75th block).

if length_read ever gets larger than 4k, truncating it to 4k

this is a dirty hack... but extraction completes.