### PR TITLE
Fixed compilation issue with meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ cpp = meson.get_compiler('cpp')
 casc_dep = cpp.find_library('casc', required : false)
 storm_dep = cpp.find_library('storm', required : false)
 png_dep = cpp.find_library('png', required : true)
+bzip2_dep = cpp.find_library('bz2', required : true)
 zlib_dep = dependency('zlib', required : false)
 imagemagickpp_dep = dependency('ImageMagick++', required : false)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,7 +39,7 @@ stratagus_incdir = include_directories(stratagus_includedir)
 
 add_project_arguments('-DDATA_PATH="' + stratagus_prefix + '/share/games/stratagus/stargus"', language: 'cpp')
 add_project_arguments('-DSCRIPTS_PATH="' + stratagus_prefix + '/share/games/stratagus/stargus"', language: 'cpp')
-add_project_arguments('-DSTRATAGUS_BIN=' + stratagus_bin, language: 'cpp')
+add_project_arguments('-DSTRATAGUS_BIN="' + stratagus_bin + '"', language: 'cpp')
 add_project_arguments('-DSOURCE_DIR="' + meson.current_source_dir() + '/../"', language: 'cpp')
 add_project_arguments('-DKS_STR_ENCODING_NONE', language: 'cpp')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,7 +51,7 @@ stargus_sources = files('stargus.cpp')
 executable('startool', 
 	startool_sources,
 	startool_kaitai_sources,
-	dependencies : [casc_dep, storm_dep, zlib_dep, png_dep, imagemagickpp_dep, log4cxx_dep],
+	dependencies : [casc_dep, storm_dep, zlib_dep, png_dep, imagemagickpp_dep, log4cxx_dep, bzip2_dep],
 	install : true)
 
 executable('stargus', 

--- a/test/module/meson.build
+++ b/test/module/meson.build
@@ -26,7 +26,7 @@ StartoolUnitTest_sources = files(
 executable('StartoolUnitTest', 
 			StartoolUnitTest_sources,
 			include_directories : StartoolUnitTest_incdir,
-			dependencies : [cppunit_dep, log4cxx_dep, storm_dep, zlib_dep, png_dep],
+			dependencies : [cppunit_dep, log4cxx_dep, storm_dep, zlib_dep, png_dep, bzip2_dep],
 			install : false)
 
 	


### PR DESCRIPTION
## Description

Error messages while compiling stargus, I had error messages about bzip functions not being declared and -DSTRATAGUS_BIN not being found.

## Specifications

OS: Arch Linux x86_64
Kernel: 5.17.3-arch1-1
Stratagus: v3.2.1-git880e90f7843831a439566b1f5989ea1584fa87ba

Steps :

1. cd stargus
2. meson build/
3. ninja -C build/

## Fixes

* Added a new dependency for startool and StartoolUnitTest
* Added missing quotes to DSTRATAGUS_BIN
