### PR TITLE
[macOS] Fix bundle.sh

### DIFF
--- a/mac/bundle.sh
+++ b/mac/bundle.sh
@@ -46,8 +46,8 @@ cd macdylibbundler
 make
 cd ..
 
-cp ../build/startool Stargus.app/Contents/MacOS/
-cp ../build/stargus Stargus.app/Contents/MacOS/
+cp ../build/src/startool Stargus.app/Contents/MacOS/
+cp ../build/src/stargus Stargus.app/Contents/MacOS/
 cp "$STRATAGUS" Stargus.app/Contents/MacOS/stratagus
 cp "$(dirname "$STRATAGUS")"/../libs/* Stargus.app/Contents/libs/
 


### PR DESCRIPTION
Meson/ninja place startool and stargus in `/build/src`, but the script is looking in `build`.

fixes #56 