### PR TITLE
[CI]:

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,13 +13,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-18.04, windows-2019]
+        os: [ubuntu-latest, ubuntu-20.04, windows-2019]
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: olegtarasov/get-tag@v2.1
+    - uses: olegtarasov/get-tag@v2.1.3
       id: tagName
 
     - name: Install ubuntu dependencies
@@ -56,7 +56,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Store windows artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: startsWith(matrix.os, 'windows')
       with:
         name: Stargus


### PR DESCRIPTION
- ubuntu-18.04 is no longer supported by github, update to ubuntu-20.04
- update action version to avoid node.js 16 warning