### PR TITLE
Add CMake flag to prefer homebrew libs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,6 +51,7 @@ jobs:
       run: |
         cmake stratagus -B stratagus/build \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_FIND_FRAMEWORK=LAST \
         -DBUILD_VENDORED_LUA=ON \
         -DBUILD_VENDORED_SDL=OFF \
         -DBUILD_VENDORED_MEDIA_LIBS=OFF \


### PR DESCRIPTION
This allows Stratagus to build using the latest `1.6.47` libpng from homebrew rather than the old `1.4.12` one.

Added to Stratagus only, Meson is already using the latest.